### PR TITLE
change naming of library view modes

### DIFF
--- a/about.md
+++ b/about.md
@@ -42,15 +42,17 @@ Library locations are classified into four types. In general mode these are:
 
 * Settler Knowledge Centres
 * Indigenous Knowledge Centres
-* Worker Pacification Centres
-* Imperial Knowledge Centres
+* Mechanics Institutes
+* Colonial Knowledge Centres
 
-If this naming convention makes you uncomfortable, you may view the map in *White fragility mode*, in which case the names are:
+If this naming convention is confusing, you may view the map in *Colonial mode*, in which case the names are:
 
 * Public Libraries
 * Indigenous Knowledge Centres
 * Mechanics Institutes
 * National & State Libraries
+
+Standard Mode invites you to think about the work these institutions do to normalise certain types of knowledge and not others.
 
 ### Important files that are not in this repository
 

--- a/website/about/index.html
+++ b/website/about/index.html
@@ -47,20 +47,21 @@
         <h3 id="caveats">Caveats</h3>
         <p>Most of the data for the map comes from government open data sources. As such it is subject to government bias, and may be out of date or over/under sampled. I make no claim or warranty that the data being complete, accurate, or up to date — though I aim for it to be all of those things. If in doubt, always check with the library directly.</p>
         <h3 id="nomenclature">Nomenclature</h3>
-        <p>Library locations are classified into four types. In general mode these are:</p>
+        <p>Library locations are classified into four types. In Standard Mode these are:</p>
         <ul>
         <li>Settler Knowledge Centres</li>
         <li>Indigenous Knowledge Centres</li>
-        <li>Worker Pacification Centres</li>
-        <li>Imperial Knowledge Centres</li>
+        <li>Mechanics Institutes</li>
+        <li>Colonial Knowledge Centres</li>
         </ul>
-        <p>If this naming convention makes you uncomfortable, you may view the map in <em>White fragility mode</em>, in which case the names are:</p>
+        <p>If this naming convention is confusing, you may view the map in <em>Colonial Mode</em>, in which case the names are:</p>
         <ul>
         <li>Public Libraries</li>
         <li>Indigenous Knowledge Centres</li>
         <li>Mechanics Institutes</li>
         <li>National &amp; State Libraries</li>
         </ul>
+        <p>Standard Mode invites you to think about the work these institutions do to normalise certain types of knowledge and not others.</p>
       </section>
     </main>
     <footer>

--- a/website/index.html
+++ b/website/index.html
@@ -49,7 +49,7 @@
   
       <div id="mode-switch">
         <div></div>
-        <button id="mode-button" name="mode-button">View in White Fragility Mode</button>
+        <button id="mode-button" name="mode-button" class="hidden"></button>
       </div>
       <!-- div to attach everything to -->
       <div id="mapid"></div>

--- a/website/load-map.js
+++ b/website/load-map.js
@@ -328,25 +328,27 @@ Promise.all([boundaries, branchesCsv, ikcCsv, mechanics, nslaBranches])
   function setGeneral() {
     overlayMaps = {
       "Settler Knowledge Centres" : branches,
-      "Indigenous Knowledge Centres": ikcs,
-      "Worker Pacification Centres" : mechsAndSoA,
-      "Imperial Knowledge Centres": otherLibs
+      "Indigenous Knowledge Centres" : ikcs,
+      "Mechanics Institutes" : mechsAndSoA,
+      "Colonial Knowledge Centres" : otherLibs
     }
-    modeButton.innerText = "View in White Fragility mode";
+    modeButton.setAttribute('class', 'visible');
+    modeButton.innerText = "View in Colonial Mode";
   }
 
-  function setFragile() {
+  function setColonial() {
     overlayMaps = {
       "Public Libraries" : branches,
-      "Indigenous Knowledge Centres": ikcs,
+      "Indigenous Knowledge Centres" : ikcs,
       "Mechanics Institutes" : mechsAndSoA,
       "National & State Libraries" : otherLibs
       };
-      modeButton.innerText = "View in General mode";
+      modeButton.setAttribute('class', 'visible');
+      modeButton.innerText = "View in Standard Mode";
   }
 
-  if (sessionStorage.getItem('mapMode') === 'fragile') {
-    setFragile()
+  if (sessionStorage.getItem('mapMode') === 'colonial') {
+    setColonial()
   } else {
     setGeneral()
   }
@@ -369,9 +371,9 @@ Promise.all([boundaries, branchesCsv, ikcCsv, mechanics, nslaBranches])
     serviceInfo: L.control({position: 'topleft'})
   }
 
-  // switching mode between standard and fragile
+  // switching mode between standard and colonial
   function switchMode() {
-    if (sessionStorage.getItem('mapMode') === 'fragile') {
+    if (sessionStorage.getItem('mapMode') === 'colonial') {
       sessionStorage.setItem('mapMode', 'general');
       setGeneral()
       mapControl.remove();
@@ -381,8 +383,8 @@ Promise.all([boundaries, branchesCsv, ikcCsv, mechanics, nslaBranches])
         infoBoxes.branches.addTo(map)
       }
     } else {
-      sessionStorage.setItem('mapMode', 'fragile');
-      setFragile()
+      sessionStorage.setItem('mapMode', 'colonial');
+      setColonial()
       mapControl.remove();
       infoBoxes.branches.remove()
       mapControl = L.control.layers(baseMaps, overlayMaps, {"collapsed": isSmallScreen}).addTo(map);
@@ -441,7 +443,6 @@ Promise.all([boundaries, branchesCsv, ikcCsv, mechanics, nslaBranches])
     }
   }
 
- 
   function zoomToFeature(e, props) {
     map.fitBounds(e.target.getBounds());
     e.target.bindPopup(`


### PR DESCRIPTION
Summary
=======

- changes "White Fragility mode" to "Colonial Mode"
- changes "General mode" to "Standard Mode"
- changes "Worker Pacification Centres" to "Mechanics Institutes"

Explanation
===========
The point of two modes is to invite map users to think about the work libraries do as institutions, and how certain types of cultural organisation are normalised and certain types are othered. In particular, why are "Indigenous Knowledge Centres" different from "public libraries", and precisely *how*?

Calling the non-standard view "White Fragility Mode" implies that the individual using it is at fault, not woke enough, fragile. This is not helpful as an invitation to be thoughtful and consider the language and perspectives that are normalised.

Changing it to 'colonial' mode shifts the emphasis to that of an institutional and structural concern, rather than an individual fault.

The change for Mechanics Institutes follows more reading about them. Their history is complicated, a mixture of genuine self-help and mutual aid, and attempts by capitalists to control their workers.